### PR TITLE
comma missing

### DIFF
--- a/examples/qwerty.json
+++ b/examples/qwerty.json
@@ -37,7 +37,7 @@
         { "pos": "K", "letters": [ "k", "K" ] },
         { "pos": "L", "letters": [ "l", "L" ] },
         { "pos": ";", "letters": [ ";", ":" ] },
-        { "pos": "'", "letters": [ "'", "\"" ] }
+        { "pos": "'", "letters": [ "'", "\"" ] },
         { "pos": "Z", "letters": [ "z", "Z" ] },
         { "pos": "X", "letters": [ "x", "X" ] },
         { "pos": "C", "letters": [ "c", "C" ] },


### PR DESCRIPTION
{ "pos": "'", "letters": [ "'", "\"" ] } needed a comma. Was wondering why my keyboard layout that I modified from qwerty wouldn't process