### PR TITLE
Set BaseChar for dead greek key to micro sign "µ"

### DIFF
--- a/src/PresetDeadKey.hs
+++ b/src/PresetDeadKey.hs
@@ -937,7 +937,7 @@ currency = DeadKey "currency" (BaseChar '¤') ∘ fst ∘ runWriter $ stringMapT
     , ("y", "¥")
     ]
 greek ∷ DeadKey' Char PresetDeadKey
-greek = DeadKey "greek" BaseNo ∘ fst ∘ runWriter $ stringMapToActionMap "greek"
+greek = DeadKey "greek" (BaseChar 'µ') ∘ fst ∘ runWriter $ stringMapToActionMap "greek"
     [ ("A", "Α")
     , ("a", "α")
     , ("B", "Β")


### PR DESCRIPTION
The dead greek keysym in libx11 was originally designed for the French BÉPO layout (along with dead currency) and thus prints the micro sign µ when followed by space or itself. [Source](https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/6d7d08726f4b0c517041842b27cd7e66e8f371eb/nls/en_US.UTF-8/Compose.pre)