### PR TITLE
Fix base character for dead belowdot

### DIFF
--- a/src/PresetDeadKey.hs
+++ b/src/PresetDeadKey.hs
@@ -516,7 +516,7 @@ iota = DeadKey "iota" (BaseChar 'ͺ') ∘ fst ∘ runWriter $ stringMapToActionM
     , ("ῶ", "ῷ")
     ]
 belowdot ∷ DeadKey' Char PresetDeadKey
-belowdot = DeadKey "belowdot" (BaseChar '\x803') ∘ fst ∘ runWriter $ stringMapToActionMap "belowdot"
+belowdot = DeadKey "belowdot" (BaseChar '\x323') ∘ fst ∘ runWriter $ stringMapToActionMap "belowdot"
     [ ("A", "Ạ")
     , ("a", "ạ")
     , ("B", "Ḅ")


### PR DESCRIPTION
It appeared to be using the decimal index of combining dot below in a hexadecimal escape string, yielding the character index of an irrelevant character in another block.